### PR TITLE
Fix issue #3: Changed the name of the visualisation window to be MNEST window instead of Pygame window

### DIFF
--- a/mnest/Environment.py
+++ b/mnest/Environment.py
@@ -121,6 +121,9 @@ class Realise:
             self.screen = pygame.display.set_mode((self.screen_width, self.screen_height))
             self.screen.fill(self.border_color)
 
+            # Title 
+            self.title = pygame.display.set_caption('MNEST Window')
+
             # This creates a dictionary with keys being layer names and the value containing a class which contains
             # information on how to display and if to display the layer.
             self.display_layers = {


### PR DESCRIPTION
This PR addresses the issue of having the visualization window having the "Pygame Window" title instead of having "MNEST window". 
The fix is relatively simple as follows: 

`self.title = pygame.display.set_caption('MNEST Window')`

1. it sets the caption of the pygame display to the desired caption.
2. it assigns that to a field in order to be used later on if needed. 